### PR TITLE
Flashfix

### DIFF
--- a/3DControls/BatteryUI/BatteryUI.tscn
+++ b/3DControls/BatteryUI/BatteryUI.tscn
@@ -6,7 +6,7 @@
 [sub_resource type="QuadMesh" id=1]
 
 [sub_resource type="ViewportTexture" id=2]
-viewport_path = NodePath("BatteryUI/Viewport")
+viewport_path = NodePath("BatteryViewport")
 
 [sub_resource type="SpatialMaterial" id=3]
 resource_local_to_scene = true

--- a/3DControls/Switch/SwitchButton.tscn
+++ b/3DControls/Switch/SwitchButton.tscn
@@ -11,10 +11,10 @@ size = Vector3( 1, 0.1, 1 )
 size = Vector2( 0.95, 0.95 )
 
 [sub_resource type="ViewportTexture" id=3]
-viewport_path = NodePath("Viewport")
+viewport_path = NodePath("Texture")
 
 [sub_resource type="ViewportTexture" id=4]
-viewport_path = NodePath("Viewport")
+viewport_path = NodePath("Texture")
 
 [sub_resource type="SpatialMaterial" id=5]
 resource_local_to_scene = true
@@ -31,24 +31,6 @@ extents = Vector3( 0.5, 0.05, 0.5 )
 
 [node name="SwitchButton" type="Spatial"]
 script = ExtResource( 1 )
-
-[node name="Button" type="MeshInstance" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0 )
-mesh = SubResource( 1 )
-material/0 = ExtResource( 2 )
-
-[node name="Text" type="MeshInstance" parent="Button"]
-transform = Transform( 1, 0, 0, 0, -1.62921e-07, 1, 0, -1, -1.62921e-07, 0, 0.06, 0 )
-mesh = SubResource( 2 )
-material/0 = SubResource( 5 )
-
-[node name="Collider" type="KinematicBody" parent="."]
-collision_layer = 2
-collision_mask = 0
-
-[node name="CollisionShape" type="CollisionShape" parent="Collider"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0 )
-shape = SubResource( 6 )
 
 [node name="Texture" type="Viewport" parent="."]
 size = Vector2( 64, 64 )
@@ -75,6 +57,24 @@ custom_colors/font_color = Color( 0.360784, 1, 0, 1 )
 text = "START"
 align = 1
 valign = 1
+
+[node name="Button" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0 )
+mesh = SubResource( 1 )
+material/0 = ExtResource( 2 )
+
+[node name="Text" type="MeshInstance" parent="Button"]
+transform = Transform( 1, 0, 0, 0, -1.62921e-07, 1, 0, -1, -1.62921e-07, 0, 0.06, 0 )
+mesh = SubResource( 2 )
+material/0 = SubResource( 5 )
+
+[node name="Collider" type="KinematicBody" parent="."]
+collision_layer = 2
+collision_mask = 0
+
+[node name="CollisionShape" type="CollisionShape" parent="Collider"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.05, 0 )
+shape = SubResource( 6 )
 
 [node name="PressSound" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 3 )

--- a/Camera/PoV.tscn
+++ b/Camera/PoV.tscn
@@ -3,12 +3,12 @@
 [ext_resource path="res://Camera/Pov.cs" type="Script" id=1]
 [ext_resource path="res://Ships/SimpleShipOne/materials/Color_B01_.material" type="Material" id=3]
 
-[sub_resource type="ViewportTexture" id=1]
-viewport_path = NodePath("Viewport3")
+[sub_resource type="Environment" id=1]
 
-[sub_resource type="DynamicFont" id=2]
+[sub_resource type="ViewportTexture" id=2]
+viewport_path = NodePath("CameraViewport")
 
-[sub_resource type="Environment" id=3]
+[sub_resource type="DynamicFont" id=3]
 
 [sub_resource type="CubeMesh" id=4]
 size = Vector3( 0.5, 0.5, 0.1 )
@@ -19,6 +19,17 @@ height = 0.25
 
 [node name="PoV" type="Spatial"]
 script = ExtResource( 1 )
+
+[node name="CameraViewport" type="Viewport" parent="."]
+size = Vector2( 1500, 1500 )
+transparent_bg = true
+keep_3d_linear = true
+
+[node name="Camera" type="Camera" parent="CameraViewport"]
+environment = SubResource( 1 )
+current = true
+fov = 160.0
+far = 10000.0
 
 [node name="Viewport" type="Viewport" parent="."]
 size = Vector2( 1500, 1500 )
@@ -35,7 +46,7 @@ expand = true
 [node name="CameraTexture" type="TextureRect" parent="Viewport"]
 anchor_right = 1.0
 anchor_bottom = 1.0
-texture = SubResource( 1 )
+texture = SubResource( 2 )
 expand = true
 __meta__ = {
 "_edit_use_anchors_": false
@@ -52,7 +63,7 @@ margin_right = 2.0
 margin_bottom = 0.5
 grow_horizontal = 2
 grow_vertical = 2
-custom_fonts/font = SubResource( 2 )
+custom_fonts/font = SubResource( 3 )
 text = "TEXT"
 align = 1
 valign = 1
@@ -64,17 +75,6 @@ __meta__ = {
 margin_right = 40.0
 margin_bottom = 40.0
 expand = true
-
-[node name="CameraViewport" type="Viewport" parent="."]
-size = Vector2( 1500, 1500 )
-transparent_bg = true
-keep_3d_linear = true
-
-[node name="Camera" type="Camera" parent="CameraViewport"]
-environment = SubResource( 3 )
-current = true
-fov = 160.0
-far = 10000.0
 
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.0493164, 0.175537 )

--- a/project.godot
+++ b/project.godot
@@ -29,6 +29,49 @@ Player="*res://Singleton/Player.cs"
 
 enabled=PoolStringArray( "ErsissSystemShipEditor" )
 
+[input]
+
+move_forward={
+"deadzone": 0.5,
+"events": [  ]
+}
+move_back={
+"deadzone": 0.5,
+"events": [  ]
+}
+move_left={
+"deadzone": 0.5,
+"events": [  ]
+}
+move_right={
+"deadzone": 0.5,
+"events": [  ]
+}
+move_up={
+"deadzone": 0.5,
+"events": [  ]
+}
+move_down={
+"deadzone": 0.5,
+"events": [  ]
+}
+roll_clockwise={
+"deadzone": 0.5,
+"events": [  ]
+}
+roll_counterclockwise={
+"deadzone": 0.5,
+"events": [  ]
+}
+sim_speed_up={
+"deadzone": 0.5,
+"events": [  ]
+}
+sim_speed_down={
+"deadzone": 0.5,
+"events": [  ]
+}
+
 [rendering]
 
 environment/default_environment="res://default_env.tres"


### PR DESCRIPTION
From [Original Pull Request](https://github.com/Enyss/Ersiss-System/pull/7) on upstream fork from @Commander-Firestrike:

> Fixed various ViewportTexture "Node not found" errors by moving the target Viewport to the top of the scene tree, and ensuring the ViewportTextures had the correct path set (see original godotengine issues: https://github.com/godotengine/godot/issues/16067 and https://github.com/godotengine/godot/issues/27790)
> 
> Also added the input mappings for the PlayerBodyController (move_forward, etc)